### PR TITLE
Enabling Macedonian hyphen for 8-bit engines

### DIFF
--- a/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
+++ b/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
@@ -27,7 +27,9 @@
     \input hyph-mk.tex
 \else
     % 8-bit engine (such as TeX or pdfTeX)
-    \message{No Macedonian hyphenation patterns - only for Unicode engines}
+    \message{UTF-8 Macedonian hyphenation patterns}
+    \input conv-utf8-t2a.tex
+	\input hyph-mk.tex
 \fi\else
     % pTeX
     \message{No Macedonian hyphenation patterns - only for Unicode engines}

--- a/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
+++ b/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
@@ -29,7 +29,7 @@
     % 8-bit engine (such as TeX or pdfTeX)
     \message{UTF-8 Macedonian hyphenation patterns}
     \input conv-utf8-t2a.tex
-	\input hyph-mk.tex
+    \input hyph-mk.tex
 \fi\else
     % pTeX
     \message{No Macedonian hyphenation patterns - only for Unicode engines}

--- a/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
+++ b/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
@@ -27,7 +27,9 @@
     \input hyph-mk.tex
 \else
     % 8-bit engine (such as TeX or pdfTeX)
-    \message{No Macedonian hyphenation patterns - only for Unicode engines}
+    \message{UTF-8 Macedonian hyphenation patterns}
+    \input conv-utf8-t2a.tex	
+    \input hyph-mk.tex
 \fi\else
     % pTeX
     \message{No Macedonian hyphenation patterns - only for Unicode engines}

--- a/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
+++ b/hyph-utf8/tex/generic/hyph-utf8/loadhyph/loadhyph-mk.tex
@@ -27,9 +27,7 @@
     \input hyph-mk.tex
 \else
     % 8-bit engine (such as TeX or pdfTeX)
-    \message{UTF-8 Macedonian hyphenation patterns}
-    \input conv-utf8-t2a.tex
-    \input hyph-mk.tex
+    \message{No Macedonian hyphenation patterns - only for Unicode engines}
 \fi\else
     % pTeX
     \message{No Macedonian hyphenation patterns - only for Unicode engines}

--- a/hyph-utf8/tex/generic/hyph-utf8/patterns/tex/hyph-mk.tex
+++ b/hyph-utf8/tex/generic/hyph-utf8/patterns/tex/hyph-mk.tex
@@ -16,8 +16,11 @@
 %     -
 %         name: Vasil Taneski
 %         contact: vasil (dot) taneski (at) gmail (dot) com
+%         minor modifications: Stojan Trajanovski
+%         contact: stojan (dot) trajanovski (at) gmail (dot) com
 % changes:
-%     - Last change 2006-09-26
+%     - Original version 2006-09-26
+%     - Last change 2020-06-11
 % texlive:
 %     babelname: macedonian
 %     message: Macedonian hyphenation patterns
@@ -189,7 +192,6 @@
 д1с2
 д1т2
 1ду
-1ѓ
 е1а
 еб1л
 еб1р
@@ -356,7 +358,6 @@
 ј1р
 2ј1с
 2ј1т
-2јќ
 1ју
 ј1ф
 2јц
@@ -640,10 +641,6 @@
 тфр2
 т1х
 2т1ч
-1ќ
-ќа1
-2ќ1н
-2ќ1т
 у1а
 уб1л
 уб1р


### PR DESCRIPTION
Enabling Macedonian hyphen for 8-bit engines

1. Adding in `loadhyph-mk.tex`: 
`\input conv-utf8-t2a.tex`
`\input hyph-mk.tex`

2. Removing in `hyph-mk.tex`:
line 192: `1ѓ`
line 359: `2јќ`
line 643: `1ќ`
line 644: `ќа1`
line 645: `2ќ1н`
line 646: `2ќ1т`
containing chars  `ќ (U+045C - cyrkje)` and `ѓ (U+0453 - cyrgje)` that are not in T2A so `conv-utf8-t2a.tex` does not catch them.

In such a way, hyphen for Macedonian would work for both unicode-aware engines (such as XeTeX or LuaTeX) and 8-bit engines (such as TeX or pdfTeX).